### PR TITLE
Fix symlink command. Source must be relative to destination.

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -3,5 +3,5 @@
 unlink ./chrome/shared
 unlink ./firefox/data/shared
 
-ln -s ./shared ./chrome/shared
-ln -s ./shared ./firefox/data/shared
+ln -s ../shared ./chrome/shared
+ln -s ../../shared ./firefox/data/shared


### PR DESCRIPTION
e.g. this currently links to `./shared` inside `./chrome/shared`, i.e. a link to itself.
